### PR TITLE
The extension supports gnome-shell 3.14

### DIFF
--- a/On_Screen_Keyboard_Button@bradan.eu/metadata.json
+++ b/On_Screen_Keyboard_Button@bradan.eu/metadata.json
@@ -1,4 +1,4 @@
 {"name": "On Screen Keyboard Button",
- "shell-version": ["3.16", "3.18", "3.20"],
+ "shell-version": ["3.14", "3.16", "3.18", "3.20"],
  "description": "Shows or hides the OSK via top bar button.",
  "uuid": "On_Screen_Keyboard_Button@bradan.eu"}


### PR DESCRIPTION
Successfully tested on gnome-shell 3.14, which is the default version coming with debian jessie (and, as a consequence, on raspbian for the raspberrypi, where the onscreen keyboard might be especially useful...)